### PR TITLE
Fix problem with trying to drop tables when they don't exist

### DIFF
--- a/setup.rb
+++ b/setup.rb
@@ -23,8 +23,8 @@ puts "CONNECTED"
 puts "Setting up Database (recreating tables) ..."
 
 ActiveRecord::Schema.define do
-  drop_table :stores
-  drop_table :employees
+  drop_table :stores if ActiveRecord::Base.connection.table_exists?(:stores)
+  drop_table :employees if ActiveRecord::Base.connection.table_exists?(:employees)
   create_table :stores do |t|
     t.column :name, :string
     t.column :annual_revenue, :integer


### PR DESCRIPTION
The setup.rb is trying to drop tables at the beginning of execution. However, in a clean database, where no tables exist, this will throw a Undefined Table error. I added if statements so that setup only tries to drop the tables when they exist.
