### PR TITLE
Add `bundle exec` to `irb` command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Follow the instructions to work on the exercises within the `exercises` folder. 
 
 You can work with the models with irb by running
 
-    irb -r './setup.rb'
+    bundle exec irb -r './setup.rb'
 
 ## Exercises
 


### PR DESCRIPTION
If the command is run without `bundle exec`, it's possible that the `pg` gem will not be found since it tries to run `irb` outside of the context of the bundle.  This can lead to a lot of confusion for students.